### PR TITLE
Adds ENV to make Minitest pass

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,2 +1,3 @@
 export PAPIERKRAM_API_SUBDOMAIN=princescammer3000
 export PAPIERKRAM_API_KEY=123lang33shlang321
+export MT_COMPAT=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  MT_COMPAT: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [next] - unreleased
 
+- [#61](https://github.com/simonneutert/papierkram_api_client/pull/61) Adds ENV to make Minitest pass ([follow Alice](https://github.com/ordinaryzelig/minispec-metadata/pull/18)). [@simonneutert](https://github.com/simonneutert)
 - [#55](https://github.com/simonneutert/papierkram_api_client/pull/55) Adds missing chapter for Transactions. [@simonneutert](https://github.com/simonneutert)
 - [#<PRNUMBER>](https://github.com/simonneutert/papierkram_api_client/pull/<PRNUMBER>) description. [@<githubusername>](https://github.com/<githubusername>)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     method_source (1.0.0)
     minispec-metadata (2.0.0)
       minitest
-    minitest (5.18.1)
+    minitest (5.19.0)
     minitest-vcr (1.4.0)
       minispec-metadata (~> 2.0)
       minitest (>= 4.7.5)
@@ -84,4 +84,4 @@ DEPENDENCIES
   vcr (~> 6.2)
 
 BUNDLED WITH
-   2.4.12
+   2.4.19


### PR DESCRIPTION
With version 5.19 Minitest insists on being called `Minitest` not `MiniTest` 🪨 