### PR TITLE
adapts to how vat_rates should be sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Schema for new entries:
 
 ## [next] - yyyy-mm-dd
 
+- [#114](https://github.com/simonneutert/papierkram_api_client/pull/114) Public API of Papierkram changed, adapt your implementation of `vat_rate` attribute, please. [@simonneutert](https://github.com/simonneutert)
 - [#<PR_NUMBER>](https://github.com/simonneutert/papierkram_api_client/pull/<PR_NUMBER>) Description. [@<username>](https://github.com/<username>)
 
 ## [0.4.1] - 2024-01-26

--- a/README.md
+++ b/README.md
@@ -505,13 +505,13 @@ voucher = client.expense_vouchers.create(
     {
       amount: 150.8,
       name: "restaurant bill",
-      vat_rate: "19%",
+      vat_rate: 0.19,
       category: "Bewirtungskosten"
     },
     {
       amount: 15,
       name: "tip",
-      vat_rate: "19%",
+      vat_rate: 0.19,
       category: "Bewirtungskosten"
     }
   ]
@@ -531,7 +531,7 @@ voucher = client.expense_vouchers.update_by(
     {
       amount: 170.8,
       name: "restaurant bill",
-      vat_rate: "19%",
+      vat_rate: 0.19,
       category: "Bewirtungskosten",
       billing: null,
       depreciation: null
@@ -539,7 +539,7 @@ voucher = client.expense_vouchers.update_by(
     {
       amount: 15,
       name: "tip",
-      vat_rate: "19%",
+      vat_rate: 0.19,
       category: "Bewirtungskosten"
     }
   ]
@@ -698,7 +698,7 @@ invoice = client.income_invoices.create(
       description: 'Anlieferung der neuen Möbel',
       quantity: 1.25,
       unit: 'Stunden',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 100
     },
     {
@@ -706,7 +706,7 @@ invoice = client.income_invoices.create(
       description: 'Bestuhlung des Bürogebäudes',
       quantity: 1.25,
       unit: 'Arbeitstage',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 800
     },
     {
@@ -714,7 +714,7 @@ invoice = client.income_invoices.create(
       description: 'Neue Bürostühle',
       quantity: 200,
       unit: 'Stühle',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 125
     }
   ]
@@ -735,7 +735,7 @@ response = client.income_invoices.update_by(
       description: 'Anlieferung der neuen Möbel',
       quantity: 1.5,
       unit: 'Stunden',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 100
     },
     {
@@ -743,7 +743,7 @@ response = client.income_invoices.update_by(
       description: 'Bestuhlung des Bürogebäudes',
       quantity: 1.5,
       unit: 'Arbeitstage',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 800
     },
     {
@@ -751,7 +751,7 @@ response = client.income_invoices.update_by(
       description: 'Neue Bürostühle',
       quantity: 200,
       unit: 'Stühle',
-      vat_rate: '19%',
+      vat_rate: 0.19,
       price: 125
     }
   ]
@@ -869,7 +869,7 @@ proposition = client.income_propositions.create(
   time_unit: 'hour',
   proposition_type: 'service',
   price: '150.0',
-  vat_rate: '19%'
+  vat_rate: 0.19
 )
 puts proposition.headers
 puts proposition.body
@@ -883,7 +883,7 @@ Siehe [Propositions#create](lib/papierkram_api/v1/endpoints/income/propositions.
 client.income_propositions.update_by(
   id: 1,
   name: 'Software design',
-  vat_rate: '19%' # verpflichtend bei Änderung
+  vat_rate: 0.19 # verpflichtend bei Änderung
 )
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,7 @@
+## From 0.4.2 onwards
+
+`vat_rate` attribute of line_items, were Strings, like "19%", but the public API of Papierkram changed and expects Floats/Decimals like `0.19`. Please update your code accordingly.
+
 ## From 0.3 to 0.4
 
 Some endpoints are calling `update` have changed. Instead of `update_by(id: 123, attributes: { ... })` you now use keywords e.g. `update_by(id: 123, name: 'New name')`.

--- a/lib/papierkram_api/v1/validators/expense_voucher.rb
+++ b/lib/papierkram_api/v1/validators/expense_voucher.rb
@@ -68,7 +68,7 @@ module PapierkramApi
               name: 'restaurant bill',
               amount: 150.8,
               category: 'Bewirtungskosten',
-              vat_rate: '19%',
+              vat_rate: 0.19,
               billing: nil,
               depreciation: nil
             },
@@ -76,7 +76,7 @@ module PapierkramApi
               name: 'tip',
               amount: 15,
               category: 'Bewirtungskosten',
-              vat_rate: '19%',
+              vat_rate: 0.19,
               billing: nil,
               depreciation: nil
             }

--- a/test/test_api_v1_client_expense_vouchers.rb
+++ b/test/test_api_v1_client_expense_vouchers.rb
@@ -67,13 +67,13 @@ class TestExpenseVouchers < Minitest::Test
           {
             amount: 150.8,
             name: 'restaurant bill',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           },
           {
             amount: 15,
             name: 'tip',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           }
         ]
@@ -103,13 +103,13 @@ class TestExpenseVouchers < Minitest::Test
           {
             amount: 150.8,
             name: 'restaurant bill',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           },
           {
             amount: 15,
             name: 'tip',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           }
         ]
@@ -144,13 +144,13 @@ class TestExpenseVouchers < Minitest::Test
           {
             amount: 150.8,
             name: 'restaurant bill',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           },
           {
             amount: 15,
             name: 'tip',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             category: 'Bewirtungskosten'
           }
         ]

--- a/test/test_api_v1_client_income_invoices.rb
+++ b/test/test_api_v1_client_income_invoices.rb
@@ -123,7 +123,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Anlieferung der neuen Möbel',
             quantity: 1.25,
             unit: 'Stunden',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 100
           },
           {
@@ -131,7 +131,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Bestuhlung des Bürogebäudes',
             quantity: 1.25,
             unit: 'Arbeitstage',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 800
           },
           {
@@ -139,7 +139,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Neue Bürostühle',
             quantity: 200,
             unit: 'Stühle',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 125
           }
         ]
@@ -162,7 +162,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Anlieferung der neuen Möbel',
             quantity: 1.5,
             unit: 'Stunden',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 100
           },
           {
@@ -170,7 +170,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Bestuhlung des Bürogebäudes',
             quantity: 1.5,
             unit: 'Arbeitstage',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 800
           },
           {
@@ -178,7 +178,7 @@ class TestIncomeInvoices < Minitest::Test
             description: 'Neue Bürostühle',
             quantity: 200,
             unit: 'Stühle',
-            vat_rate: '19%',
+            vat_rate: 0.19,
             price: 125
           }
         ]

--- a/test/test_api_v1_client_income_propsitions.rb
+++ b/test/test_api_v1_client_income_propsitions.rb
@@ -32,7 +32,7 @@ class TestIncomePropositions < Minitest::Test
         time_unit: 'hour',
         proposition_type: 'service',
         price: '150.0',
-        vat_rate: '19%'
+        vat_rate: 0.19
       )
       response_body = response.body
 


### PR DESCRIPTION
`vat_rate` (for a line_item) should be sent as decimal.

Though it will work with a proper formatted String, too 🤷‍♂️ 

Please, see changes in this PR for implementation details.

#### Test

I should rerecord the ver cassettes, but decided to do it in a future release, as the implementation is still working as is.

## Before

```json
{
  vat_rate: "19%"
}
```

## After

```json
{
  vat_rate: 0.19
}
```